### PR TITLE
e2e-test logf instead framework.logf

### DIFF
--- a/test/e2e/cloud/BUILD
+++ b/test/e2e/cloud/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -46,7 +47,7 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 		nodeToDelete := nodeDeleteCandidates.Items[0]
 
 		origNodes := framework.GetReadyNodesIncludingTaintedOrDie(c)
-		framework.Logf("Original number of ready nodes: %d", len(origNodes.Items))
+		e2elog.Logf("Original number of ready nodes: %d", len(origNodes.Items))
 
 		err := framework.DeleteNodeOnCloudProvider(&nodeToDelete)
 		if err != nil {


### PR DESCRIPTION
/kind cleanup
/priority backlog

What this PR does / why we need it:

Move e2e/cloud test to use e2e.Logf

Ref #77359

Does this PR introduce a user-facing change?:

```
NONE
```